### PR TITLE
Add workflow for training and prediction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean data lint requirements sync_data_to_s3 sync_data_from_s3
+.PHONY: clean data lint requirements sync_data_to_s3 sync_data_from_s3 train predict
 
 #################################################################################
 # GLOBALS                                                                       #
@@ -28,6 +28,14 @@ requirements: test_environment
 ## Make Dataset
 data: requirements
 	$(PYTHON_INTERPRETER) src/data/make_dataset.py data/raw data/processed
+
+## Train the model
+train:
+	dvc repro train_model
+
+## Make predictions
+predict:
+	$(PYTHON_INTERPRETER) src/models/predict_model.py
 
 ## Delete all compiled Python files
 clean:

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -9,3 +9,15 @@ stages:
     - make_dataset.test_split
     outs:
     - data\external
+
+  train_model:
+    cmd: python src/models/train_model.py
+    deps:
+    - data\external\train_data.csv
+    - src\models\train_model.py
+    params:
+    - train_model.learning_rate
+    - train_model.n_estimators
+    - train_model.max_depth
+    outs:
+    - models\trained_model.pkl

--- a/src/models/predict_model.py
+++ b/src/models/predict_model.py
@@ -1,0 +1,79 @@
+import pandas as pd
+import numpy as np
+import pathlib
+import joblib
+from sklearn.preprocessing import StandardScaler
+import sys
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def load_data(path):
+    try:
+        df = pd.read_csv(path)
+        logger.info(f"Data loaded successfully from {path}")
+        return df
+    except Exception as e:
+        logger.error(f"Failed to load data from {path}: {e}")
+        sys.exit(1)
+
+def load_model(path):
+    try:
+        model = joblib.load(path)
+        logger.info(f"Model loaded successfully from {path}")
+        return model
+    except Exception as e:
+        logger.error(f"Failed to load model from {path}: {e}")
+        sys.exit(1)
+
+def scale_data(data, scaler_path):
+    try:
+        scaler = joblib.load(scaler_path)
+        data_scaled = scaler.transform(data)
+        logger.info("Data scaled successfully")
+        return data_scaled
+    except Exception as e:
+        logger.error(f"Failed to scale data: {e}")
+        sys.exit(1)
+
+def make_predictions(model, data):
+    try:
+        predictions = model.predict(data)
+        logger.info("Predictions made successfully")
+        return predictions
+    except Exception as e:
+        logger.error(f"Failed to make predictions: {e}")
+        sys.exit(1)
+
+def save_predictions(predictions, path):
+    try:
+        np.savetxt(path, predictions, delimiter=",")
+        logger.info(f"Predictions saved successfully to {path}")
+    except Exception as e:
+        logger.error(f"Failed to save predictions to {path}: {e}")
+        sys.exit(1)
+
+def main():
+    try:
+        curr_dir = pathlib.Path(__file__)
+        home_dir = curr_dir.parent.parent.parent
+        
+        input_file = '/data/external/test_data.csv'
+        data_path = home_dir.as_posix() + input_file
+        model_path = home_dir.as_posix() + '/models/trained_model.pkl'
+        scaler_path = home_dir.as_posix() + '/models/scaler.pkl'
+        predictions_path = home_dir.as_posix() + '/data/predictions/predictions.csv'
+        
+        data = load_data(data_path)
+        model = load_model(model_path)
+        data_scaled = scale_data(data, scaler_path)
+        predictions = make_predictions(model, data_scaled)
+        save_predictions(predictions, predictions_path)
+    except Exception as e:
+        logger.error(f"Failed to execute main function: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/src/models/train_model.py
+++ b/src/models/train_model.py
@@ -1,0 +1,89 @@
+import pandas as pd
+import numpy as np
+import pathlib
+import joblib
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+from sklearn.metrics import accuracy_score, confusion_matrix, classification_report
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.svm import SVC
+from xgboost import XGBClassifier
+import yaml
+import sys
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def load_data(path):
+    try:
+        df = pd.read_csv(path)
+        logger.info(f"Data loaded successfully from {path}")
+        return df
+    except Exception as e:
+        logger.error(f"Failed to load data from {path}: {e}")
+        sys.exit(1)
+
+def data_split(data, test_size, random_state):
+    try:
+        X = data.iloc[:, :-1]
+        y = data.iloc[:, -1]
+        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=test_size, random_state=random_state)
+        logger.info("Data split successfully into train and test sets")
+        return X_train, X_test, y_train, y_test
+    except Exception as e:
+        logger.error(f"Failed to split data: {e}")
+        sys.exit(1)
+
+def scale_data(X_train, X_test):
+    try:
+        scaler = StandardScaler()
+        X_train_scaled = scaler.fit_transform(X_train)
+        X_test_scaled = scaler.transform(X_test)
+        logger.info("Data scaled successfully")
+        return X_train_scaled, X_test_scaled
+    except Exception as e:
+        logger.error(f"Failed to scale data: {e}")
+        sys.exit(1)
+
+def train_model(X_train, y_train):
+    try:
+        model = RandomForestClassifier(n_estimators=100, random_state=42)
+        model.fit(X_train, y_train)
+        logger.info("Model trained successfully")
+        return model
+    except Exception as e:
+        logger.error(f"Failed to train model: {e}")
+        sys.exit(1)
+
+def save_model(model, path):
+    try:
+        joblib.dump(model, path)
+        logger.info(f"Model saved successfully to {path}")
+    except Exception as e:
+        logger.error(f"Failed to save model to {path}: {e}")
+        sys.exit(1)
+
+def main():
+    try:
+        curr_dir = pathlib.Path(__file__)
+        home_dir = curr_dir.parent.parent.parent
+        params_file = home_dir.as_posix() + '/params.yaml'
+        params = yaml.safe_load(open(params_file))["train_model"]
+        
+        input_file = '/data/external/train_data.csv'
+        data_path = home_dir.as_posix() + input_file
+        model_path = home_dir.as_posix() + '/models/trained_model.pkl'
+        
+        data = load_data(data_path)
+        X_train, X_test, y_train, y_test = data_split(data, params['test_split'], params['seed'])
+        X_train_scaled, X_test_scaled = scale_data(X_train, X_test)
+        model = train_model(X_train_scaled, y_train)
+        save_model(model, model_path)
+    except Exception as e:
+        logger.error(f"Failed to execute main function: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add workflow for training and predicting models.

* **dvc.yaml**: Add a new stage for training the model using `src/models/train_model.py` with dependencies, parameters, and outputs.
* **Makefile**: Add `train` command to run the training stage defined in `dvc.yaml` and `predict` command to run the prediction script `src/models/predict_model.py`.
* **src/models/train_model.py**: Implement script to train the model using the training data, including loading data, splitting data, scaling data, training the model, and saving the model.
* **src/models/predict_model.py**: Implement script to make predictions using the trained model, including loading data, loading the model, scaling data, making predictions, and saving predictions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Akshar062/Heart-attack/pull/2?shareId=50ed5587-b5e4-4dbd-93ac-f23cfa5ad169).